### PR TITLE
fix: broken creator profile link in event/place detail

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -144,7 +144,7 @@ export const Card: FC<CardProps> = memo(({ data, isLoading = false, children, cr
             <CreatorLabel>{formatMessage('card.creator.by')} </CreatorLabel>
             {displayUser ? (
               <UserProfileLink
-                href={`${config.get('PROFILE_URL')}accounts/${displayUser}`}
+                href={`${config.get('PROFILE_URL').replace(/\/$/, '')}/accounts/${displayUser}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={formatMessage('card.accessibility.user_profile_link', { userName: displayUserName })}

--- a/src/components/MobileCard/MobileCard.tsx
+++ b/src/components/MobileCard/MobileCard.tsx
@@ -142,7 +142,7 @@ export const MobileCard: FC<MobileCardProps> = memo(({ data, isLoading = false, 
             <CreatorLabel>{formatMessage('card.creator.by')} </CreatorLabel>
             {displayUser ? (
               <MobileUserProfileLink
-                href={`${config.get('PROFILE_URL')}accounts/${displayUser}`}
+                href={`${config.get('PROFILE_URL').replace(/\/$/, '')}/accounts/${displayUser}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={formatMessage('card.accessibility.user_profile_link', { userName: displayUserName })}


### PR DESCRIPTION
Fixes a malformed creator profile URL (e.g. `https://profile.decentraland.orgaccounts/0x...`) by normalizing the trailing   
  slash on `PROFILE_URL` before concatenating `accounts/`. Works regardless of whether the configured `PROFILE_URL` ends with a 
  slash.